### PR TITLE
Update to litebird_sim 0.17.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,8 @@ keywords = ["astronomy", "simulation", "scanning"]
 dependencies = [
     "numpy>=1.26.4",
     "numba>=0.61.2",
-    "astropy==6.1.7",
-    "litebird_sim>=0.16.0",
+    "astropy>=6.1.7",
+    "litebird_sim>=0.17.0",
 ]
 
 [project.optional-dependencies]
@@ -47,7 +47,7 @@ target-version = "py310"
 select = ["E", "F", "W", "I", "N", "UP"]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false

--- a/swipe_modules/common.py
+++ b/swipe_modules/common.py
@@ -23,13 +23,13 @@ def _ct_jd_to_lst_rad(
     longitude_rad: float,
 ) -> float:
     """Compute the local sidereal time as a function of Julian Day.
-    
+
     Adapted from the astrolib routine ct2lst.pro.
-    
+
     Args:
         time_jd: Time in Julian Days.
         longitude_rad: Longitude in radians.
-        
+
     Returns:
         Local sidereal time in radians.
     """
@@ -50,16 +50,16 @@ def _ct_jd_to_lst_rad(
 @njit
 def _equinox_precession_rad(time_jd: float) -> float:
     """Compute the precession of the equinox with respect to J2000.
-    
+
     Very rough estimation but sufficient for the SWIPE beam (~2 arcmin error).
-    
+
     References:
         - https://en.wikipedia.org/wiki/Axial_precession#Values
         - https://syrte.obspm.fr/iau2006/aa03_412_P03.pdf
-        
+
     Args:
         time_jd: Time in Julian Days.
-        
+
     Returns:
         Precession angle in radians.
     """
@@ -71,16 +71,16 @@ def _equinox_precession_rad(time_jd: float) -> float:
 @njit
 def _equator_ecliptic_angle_rad(time_jd: float) -> float:
     """Compute the obliquity of the ecliptic with respect to J2000.
-    
+
     Third-order polynomial approximation.
-    
+
     References:
         - https://en.wikipedia.org/wiki/Ecliptic#Obliquity_of_the_ecliptic
         - https://syrte.obspm.fr/iau2006/aa03_412_P03.pdf
-        
+
     Args:
         time_jd: Time in Julian Days.
-        
+
     Returns:
         Obliquity angle in radians.
     """
@@ -98,10 +98,10 @@ def _equator_ecliptic_angle_rad(time_jd: float) -> float:
 @njit
 def _chiA_rad(time_jd: float) -> float:
     """Compute chi_A precession component in radians.
-    
+
     Args:
         time_jd: Time in Julian Days.
-        
+
     Returns:
         chi_A angle in radians.
     """
@@ -117,10 +117,10 @@ def _chiA_rad(time_jd: float) -> float:
 @njit
 def _zitaA_rad(time_jd: float) -> float:
     """Compute zeta_A precession component in radians.
-    
+
     Args:
         time_jd: Time in Julian Days.
-        
+
     Returns:
         zeta_A angle in radians.
     """
@@ -138,10 +138,10 @@ def _zitaA_rad(time_jd: float) -> float:
 @njit
 def _zetaA_rad(time_jd: float) -> float:
     """Compute zeta_A precession component in radians.
-    
+
     Args:
         time_jd: Time in Julian Days.
-        
+
     Returns:
         zeta_A angle in radians.
     """
@@ -159,10 +159,10 @@ def _zetaA_rad(time_jd: float) -> float:
 @njit
 def _thetaA_rad(time_jd: float) -> float:
     """Compute theta_A precession component in radians.
-    
+
     Args:
         time_jd: Time in Julian Days.
-        
+
     Returns:
         theta_A angle in radians.
     """

--- a/swipe_modules/raster_scanning_strategy.py
+++ b/swipe_modules/raster_scanning_strategy.py
@@ -5,9 +5,6 @@ from uuid import UUID
 
 import astropy.time
 import numpy as np
-from numba import njit
-from scipy import interpolate
-
 from litebird_sim import RotQuaternion, ScanningStrategy
 from litebird_sim.imo import Imo
 from litebird_sim.quaternions import (
@@ -15,9 +12,9 @@ from litebird_sim.quaternions import (
     quat_rotation_x,
     quat_rotation_y,
     quat_rotation_z,
-    rotate_x_vector,
-    rotate_z_vector,
 )
+from numba import njit
+from scipy import interpolate
 
 from .common import (
     _ct_jd_to_lst_rad,
@@ -44,13 +41,13 @@ def _sawtooth(
     speed: float,
 ) -> float:
     """Generate a sawtooth waveform.
-    
+
     Args:
         time: Time value.
         offset: Offset of the sawtooth.
         amplitude: Amplitude of the sawtooth.
         speed: Speed parameter.
-        
+
     Returns:
         Sawtooth waveform value.
     """
@@ -59,7 +56,7 @@ def _sawtooth(
         return offset
     else:
         r = time / amplitude * speed
-        x = 4 * np.abs((r - np.floor(r + 0.5)))  # - 1
+        x = 4 * np.abs(r - np.floor(r + 0.5))  # - 1
         return offset + amplitude * x / 2
 
 
@@ -75,7 +72,7 @@ def _SWIPEraster_spin_to_ecliptic(
     time_jd: float,
 ) -> None:
     """Compute spin-to-ecliptic quaternion for raster scanning.
-    
+
     Args:
         result: Output quaternion array (4-element).
         colatitude_rad: Latitude in radians.
@@ -119,7 +116,7 @@ def _SWIPEraster_all_spin_to_ecliptic(
     time_vector_jd: np.ndarray,
 ) -> None:
     """Compute spin-to-ecliptic quaternions for all times in raster scanning.
-    
+
     Args:
         result_matrix: Output quaternion matrix (N x 4).
         colatitude_rad: Colatitude values in radians.
@@ -146,10 +143,10 @@ def _SWIPEraster_all_spin_to_ecliptic(
 
 class SwipeRasterScanningStrategy(ScanningStrategy):
     """Sky scanning strategy for SWIPE with raster scanning pattern.
-    
+
     This class defines the scanning parameters for the SWIPE balloon-borne
     instrument, supporting both fixed sites and balloon trajectories.
-    
+
     Attributes:
         site_colatitude_rad (float): Colatitude of the site in radians.
         site_longitude_rad (float): Longitude of the site in radians.
@@ -161,10 +158,10 @@ class SwipeRasterScanningStrategy(ScanningStrategy):
         balloon_colatitude_rad (ndarray | None): Balloon colatitude trajectory.
         balloon_longitude_rad (ndarray | None): Balloon longitude trajectory.
         balloon_time (list[astropy.time.Time] | None): Balloon time points.
-        
+
     Example:
         Use :meth:`.from_imo` to create an instance from IMO parameters:
-        
+
         >>> imo = Imo()
         >>> sstr = SwipeRasterScanningStrategy.from_imo(
         ...     imo=imo,
@@ -199,7 +196,9 @@ class SwipeRasterScanningStrategy(ScanningStrategy):
         if balloon_latitude_deg is None:
             self.balloon_colatitude_rad = None
         else:
-            self.balloon_colatitude_rad = np.deg2rad(_EQUATORIAL_COLATITUDE_DEG - balloon_latitude_deg)
+            self.balloon_colatitude_rad = np.deg2rad(
+                _EQUATORIAL_COLATITUDE_DEG - balloon_latitude_deg
+            )
 
         if balloon_longitude_deg is None:
             self.balloon_longitude_rad = None
@@ -221,39 +220,24 @@ class SwipeRasterScanningStrategy(ScanningStrategy):
     def __repr__(self):
         return (
             (
-                "SwipeRasterScanningStrategy(site_colatitude_rad={site_colatitude_rad}, "
-                "site_longitude_rad={site_longitude_rad},"
-                "longitude_speed_rad_per_sec={longitude_speed_rad_per_sec}, "
-                "azimuth_start_rad={azimuth_start_rad}, "
-                "azimuth_amplitude_rad={azimuth_amplitude_rad}, "
-                "azimuth_scan_speed_rad_per_s={azimuth_scan_speed_rad_per_s}, "
-                "start_time={start_time})".format(
-                    site_colatitude_rad=self.site_colatitude_rad,
-                    site_longitude_rad=self.site_longitude_rad,
-                    longitude_speed_rad_per_sec=self.longitude_speed_rad_per_sec,
-                    azimuth_start_rad=self.azimuth_start_rad,
-                    azimuth_amplitude_rad=self.azimuth_amplitude_rad,
-                    azimuth_scan_speed_rad_per_s=self.azimuth_scan_speed_rad_per_s,
-                    start_time=self.start_time,
-                )
+                f"SwipeRasterScanningStrategy(site_colatitude_rad={self.site_colatitude_rad}, "
+                f"site_longitude_rad={self.site_longitude_rad},"
+                f"longitude_speed_rad_per_sec={self.longitude_speed_rad_per_sec}, "
+                f"azimuth_start_rad={self.azimuth_start_rad}, "
+                f"azimuth_amplitude_rad={self.azimuth_amplitude_rad}, "
+                f"azimuth_scan_speed_rad_per_s={self.azimuth_scan_speed_rad_per_s}, "
+                f"start_time={self.start_time})"
             )
             if (
                 (self.balloon_colatitude_rad is None)
                 and (self.balloon_longitude_rad is None)
             )
             else (
-                "SwipeRasterScanningStrategy(colatitude_range_rad=[{min_colatitude_rad},{max_colatitude_rad}],"
-                "azimuth_start_rad={azimuth_start_rad}, "
-                "azimuth_amplitude_rad={azimuth_amplitude_rad}, "
-                "azimuth_scan_speed_rad_per_s={azimuth_scan_speed_rad_per_s}, "
-                "start_time={start_time})".format(
-                    min_colatitude_rad=self.balloon_colatitude_rad.min(),
-                    max_colatitude_rad=self.balloon_colatitude_rad.max(),
-                    azimuth_start_rad=self.azimuth_start_rad,
-                    azimuth_amplitude_rad=self.azimuth_amplitude_rad,
-                    azimuth_scan_speed_rad_per_s=self.azimuth_scan_speed_rad_per_s,
-                    start_time=self.start_time,
-                )
+                f"SwipeRasterScanningStrategy(colatitude_range_rad=[{self.balloon_colatitude_rad.min()},{self.balloon_colatitude_rad.max()}],"
+                f"azimuth_start_rad={self.azimuth_start_rad}, "
+                f"azimuth_amplitude_rad={self.azimuth_amplitude_rad}, "
+                f"azimuth_scan_speed_rad_per_s={self.azimuth_scan_speed_rad_per_s}, "
+                f"start_time={self.start_time})"
             )
         )
 
@@ -269,7 +253,7 @@ class SwipeRasterScanningStrategy(ScanningStrategy):
         time_vector_jd: np.ndarray,
     ) -> None:
         """Compute spin-to-ecliptic quaternions for array of times.
-        
+
         Args:
             result_matrix: Output quaternion matrix (N x 4).
             colatitude_rad: Colatitude values in radians.
@@ -297,15 +281,15 @@ class SwipeRasterScanningStrategy(ScanningStrategy):
     @staticmethod
     def from_imo(imo: Imo, url: str | UUID) -> "SwipeRasterScanningStrategy":
         """Read scanning strategy parameters from the IMO database.
-        
+
         Args:
             imo: An IMO database instance.
             url: IMO reference path or UUID for the scanning parameters.
                 Example: "/releases/v0.0/balloon/scanning_parameters/"
-                
+
         Returns:
             SwipeRasterScanningStrategy instance with IMO parameters.
-            
+
         Example:
             >>> imo = Imo()
             >>> sstr = SwipeRasterScanningStrategy.from_imo(
@@ -331,12 +315,12 @@ class SwipeRasterScanningStrategy(ScanningStrategy):
         delta_time_s: float,
     ) -> RotQuaternion:
         """Generate spin-to-ecliptic quaternions for a time span.
-        
+
         Args:
             start_time: Start time of quaternion generation.
             time_span_s: Duration to cover in seconds.
             delta_time_s: Sampling interval in seconds.
-            
+
         Returns:
             RotQuaternion: Quaternion time series.
         """

--- a/swipe_modules/spin_scanning_strategy.py
+++ b/swipe_modules/spin_scanning_strategy.py
@@ -5,19 +5,16 @@ from uuid import UUID
 
 import astropy.time
 import numpy as np
-from numba import njit
-from scipy import interpolate
-
-from litebird_sim import RotQuaternion, ScanningStrategy, calculate_sun_earth_angles_rad
+from litebird_sim import RotQuaternion, ScanningStrategy
 from litebird_sim.imo import Imo
 from litebird_sim.quaternions import (
     quat_left_multiply,
     quat_rotation_x,
     quat_rotation_y,
     quat_rotation_z,
-    rotate_x_vector,
-    rotate_z_vector,
 )
+from numba import njit
+from scipy import interpolate
 
 from .common import (
     _ct_jd_to_lst_rad,
@@ -46,7 +43,7 @@ def _SWIPEspin_spin_to_ecliptic(
     time_jd: float,
 ) -> None:
     """Compute spin-to-ecliptic quaternion for spin scanning.
-    
+
     Args:
         result: Output quaternion array (4-element).
         colatitude_rad: Colatitude in radians.
@@ -78,7 +75,7 @@ def _SWIPEspin_all_spin_to_ecliptic(
     time_vector_jd: np.ndarray,
 ) -> None:
     """Compute spin-to-ecliptic quaternions for all times in spin scanning.
-    
+
     Args:
         result_matrix: Output quaternion matrix (N x 4).
         colatitude_rad: Colatitude values in radians.
@@ -101,11 +98,11 @@ def _SWIPEspin_all_spin_to_ecliptic(
 
 class SwipeSpinScanningStrategy(ScanningStrategy):
     """Sky scanning strategy for SWIPE with spin scanning pattern.
-    
+
     This class defines the scanning parameters for the SWIPE balloon-borne
     instrument with spinning motion, supporting both fixed sites and balloon
     trajectories.
-    
+
     Attributes:
         site_colatitude_rad (float): Colatitude of the site in radians.
         site_longitude_rad (float): Longitude of the site in radians.
@@ -115,10 +112,10 @@ class SwipeSpinScanningStrategy(ScanningStrategy):
         balloon_colatitude_rad (ndarray | None): Balloon colatitude trajectory.
         balloon_longitude_rad (ndarray | None): Balloon longitude trajectory.
         balloon_time (list[astropy.time.Time] | None): Balloon time points.
-        
+
     Example:
         Use :meth:`.from_imo` to create an instance from IMO parameters:
-        
+
         >>> imo = Imo()\n        >>> sstr = SwipeSpinScanningStrategy.from_imo(
         ...     imo=imo,
         ...     url=\"/releases/v0.0/balloon/scanning_parameters/\",
@@ -143,15 +140,17 @@ class SwipeSpinScanningStrategy(ScanningStrategy):
 
         self.spin_rate_hz = spin_rate_rmp / _SECONDS_PER_MINUTE
         self.start_time = (
-            start_time 
-            if start_time is not None 
+            start_time
+            if start_time is not None
             else astropy.time.Time(_DEFAULT_START_TIME, scale="tdb")
         )
 
         if balloon_latitude_deg is None:
             self.balloon_colatitude_rad = None
         else:
-            self.balloon_colatitude_rad = np.deg2rad(_EQUATORIAL_COLATITUDE_DEG - balloon_latitude_deg)
+            self.balloon_colatitude_rad = np.deg2rad(
+                _EQUATORIAL_COLATITUDE_DEG - balloon_latitude_deg
+            )
 
         if balloon_longitude_deg is None:
             self.balloon_longitude_rad = None
@@ -201,7 +200,7 @@ class SwipeSpinScanningStrategy(ScanningStrategy):
         time_vector_jd: np.ndarray,
     ) -> None:
         """Compute spin-to-ecliptic quaternions for array of times.
-        
+
         Args:
             result_matrix: Output quaternion matrix (N x 4).
             colatitude_rad: Colatitude values in radians.
@@ -225,15 +224,15 @@ class SwipeSpinScanningStrategy(ScanningStrategy):
     @staticmethod
     def from_imo(imo: Imo, url: str | UUID) -> "SwipeSpinScanningStrategy":
         """Read scanning strategy parameters from the IMO database.
-        
+
         Args:
             imo: An IMO database instance.
             url: IMO reference path or UUID for the scanning parameters.
                 Example: \"/releases/v0.0/balloon/scanning_parameters/\"
-                
+
         Returns:
             SwipeSpinScanningStrategy instance with IMO parameters.
-            
+
         Example:
             >>> imo = Imo()
             >>> sstr = SwipeSpinScanningStrategy.from_imo(
@@ -257,12 +256,12 @@ class SwipeSpinScanningStrategy(ScanningStrategy):
         delta_time_s: float,
     ) -> RotQuaternion:
         """Generate spin-to-ecliptic quaternions for a time span.
-        
+
         Args:
             start_time: Start time of quaternion generation.
             time_span_s: Duration to cover in seconds.
             delta_time_s: Sampling interval in seconds.
-            
+
         Returns:
             RotQuaternion: Quaternion time series.
         """


### PR DESCRIPTION
## Summary
- Bump `litebird_sim>=0.17.0` and unpin `astropy` (was hard-pinned to `6.1.7`, incompatible with the numpy 2.x that litebird_sim 0.17 pulls in — `astropy.time` fails to import with `AttributeError: module 'numpy' has no attribute 'in1d'`).
- Bump `tool.mypy.python_version` to 3.12 (numpy's stubs now use PEP 695 syntax mypy can't parse under an older target).
- Ruff lint cleanup (whitespace, line length) via `ruff check --fix`.

## Test plan
- [x] `pip install -e .` with `litebird_sim==0.17.0`, `astropy==8.0.1`, `numpy==2.5.2`
- [x] Import `swipe_modules` and run `SwipeSpinScanningStrategy`/`SwipeRasterScanningStrategy` with no errors or deprecation warnings
- [x] `ruff check swipe_modules/` — only pre-existing N802 naming warnings on private astro-convention functions remain
- [x] All four example notebooks (`test_swipe_raster_scan`, `test_swipe_scan_realistic`, `test_swipe_produce_maps`, `test_swipe_produce_maps_imo`) execute end-to-end via `jupyter nbconvert --execute`

🤖 Generated with [Claude Code](https://claude.com/claude-code)