### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "swipe_modules"
-version = "0.2.0"
+version = "0.2.1"
 description = "Routines that adapt litebird_sim to LSPE-SWIPE"
 readme = "README.md"
 license = {text = "GPL"}

--- a/swipe_modules/__init__.py
+++ b/swipe_modules/__init__.py
@@ -4,7 +4,7 @@ from .common import data_directory
 from .raster_scanning_strategy import SwipeRasterScanningStrategy
 from .spin_scanning_strategy import SwipeSpinScanningStrategy
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __author__ = "Luca Pagano"
 __author_email__ = "luca.pagano@unife.it"
 


### PR DESCRIPTION
Version bump for release. v0.2.0 was already taken by a stale tag from 2022, so this is 0.2.1 instead. See release notes for the full changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)