### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+build/
+dist/
+
+# Jupyter
+.ipynb_checkpoints/
+examples/cmb/
+
+# Editors / OS
+.vscode/
+.DS_Store


### PR DESCRIPTION
Covers __pycache__/, egg-info/, build/dist artifacts, notebook checkpoints, the examples/cmb/ FITS output produced by running the example notebooks, and editor/OS cruft (.vscode/, .DS_Store) -- all of which kept showing up as untracked noise in `git status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)