### PR TITLE
Fix README: missing numpy import, stale python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It sould contain:
 Set up the enviroment (if necessary)
 ```
 # Create a conda environment
-conda create -n swipe_env python=3.8
+conda create -n swipe_env python=3.12
 
 # Activate the environment
 conda activate swipe_env
@@ -44,6 +44,7 @@ from swipe_modules import SwipeSpinScanningStrategy
 import litebird_sim as lbs
 import healpy as hp
 import astropy
+import numpy as np
 
 # Initialize the simulation
 sim = lbs.Simulation(


### PR DESCRIPTION
## Summary
Verified all four example notebooks and the README's Usage snippet against litebird_sim 0.17.0 -- APIs (`Simulation`, `InstrumentInfo`, `DetectorInfo`, `from_imo`, `IdealHWP`, `SkyGenerationParams`, `prepare_pointings`/`precompute_pointings`, `pointing_matrix`) are all still compatible, no code changes needed there.

The README's Usage snippet itself was broken though: it calls `np.deg2rad(...)` without importing numpy, so copy-pasting it as-is raises `NameError`. Also bumped the conda `python=` example from 3.8, which predates `pyproject.toml`'s `requires-python = ">=3.10,<3.14"`.

## Test plan
- [x] All four example notebooks execute end-to-end via `jupyter nbconvert --execute` against litebird_sim 0.17.0
- [x] Extracted and ran the README's Usage code block verbatim -- confirmed it fails without the fix (`NameError: name 'np' is not defined`) and passes with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)